### PR TITLE
Increment version number for each document request

### DIFF
--- a/lib/asari.rb
+++ b/lib/asari.rb
@@ -103,7 +103,7 @@ class Asari
   #
   def add_item(id, fields)
     return nil if self.class.mode == :sandbox
-    query = { "type" => "add", "id" => id.to_s, "version" => 1, "lang" => "en" }
+    query = { "type" => "add", "id" => id.to_s, "version" => Time.now.to_i, "lang" => "en" }
     fields.each do |k,v|
       fields[k] = "" if v.nil?
     end
@@ -147,7 +147,7 @@ class Asari
   def remove_item(id)
     return nil if self.class.mode == :sandbox
 
-    query = { "type" => "delete", "id" => id.to_s, "version" => 2 }
+    query = { "type" => "delete", "id" => id.to_s, "version" => Time.now.to_i }
     doc_request query
   end
 

--- a/spec/documents_spec.rb
+++ b/spec/documents_spec.rb
@@ -6,6 +6,7 @@ describe Asari do
       @asari = Asari.new("testdomain")
       stub_const("HTTParty", double())
       HTTParty.stub(:post).and_return(fake_post_success)
+      Time.should_receive(:now).and_return(1)
     end
 
     it "allows you to add an item to the index." do
@@ -21,7 +22,7 @@ describe Asari do
     end
 
     it "allows you to delete an item from the index." do
-      HTTParty.should_receive(:post).with("http://doc-testdomain.us-east-1.cloudsearch.amazonaws.com/2011-02-01/documents/batch", { :body => [{ "type" => "delete", "id" => "1", "version" => 2}].to_json, :headers => { "Content-Type" => "application/json"}})
+      HTTParty.should_receive(:post).with("http://doc-testdomain.us-east-1.cloudsearch.amazonaws.com/2011-02-01/documents/batch", { :body => [{ "type" => "delete", "id" => "1", "version" => 1}].to_json, :headers => { "Content-Type" => "application/json"}})
 
       expect(@asari.remove_item("1")).to eq(nil)
     end


### PR DESCRIPTION
This fixes updating documents. Ideally, in order to have a better control over document version, there should be an interface to provide an explicit version number, till that interface is provided, document version can be incremented for every doc request using `Time.now.to_i`
