### PR TITLE
Remove duplicated code and allowed models to optionally define the hash of data to send to the CloudSearch.

### DIFF
--- a/lib/asari/active_record.rb
+++ b/lib/asari/active_record.rb
@@ -86,10 +86,7 @@ class Asari
         if self.asari_when
           return unless asari_should_index?(obj)
         end
-        data = {}
-        self.asari_fields.each do |field|
-          data[field] = obj.send(field) || ""
-        end
+        data = self.asari_data_item(obj)
         self.asari_instance.add_item(obj.send(:id), data)
       rescue Asari::DocumentUpdateException => e
         self.asari_on_error(e)
@@ -104,13 +101,21 @@ class Asari
             return
           end
         end
-        data = {}
-        self.asari_fields.each do |field|
-          data[field] = obj.send(field)
-        end
+        data = self.asari_data_item(obj)
         self.asari_instance.update_item(obj.send(:id), data)
       rescue Asari::DocumentUpdateException => e
         self.asari_on_error(e)
+      end
+
+      # Gather all the data to send to the CloudSearch
+      # Can be overriden by the model to adapt to special cases.
+      # Returns a hash of the data to send to the CloudSearch
+      def asari_data_item(obj)
+        data = {}
+        self.asari_fields.each do |field|
+          data[field] = obj.send(field) || ""
+        end
+        data
       end
 
       # Internal: method for removing a soon-to-be deleted item from the CloudSearch


### PR DESCRIPTION
I did not perform many pull requests so I am unsure if I do the right thing.

I noticed some duplicated code which I refactored into a single method.
This has also the benefit of allowing each model to optionally define how the hash of data should be constructed to adapt to special cases.

Let me know if you have any questions or if you need me to make any corrections like the name of the method or the comments.
