### PR TITLE
custom AWS url, support for ActiveSupport::TimeWithZone & use RFC3339 for time objects

### DIFF
--- a/lib/asari.rb
+++ b/lib/asari.rb
@@ -235,10 +235,18 @@ class Asari
     rank[1] == :desc ? "-#{rank[0]}" : rank[0]
   end
 
-  def convert_date_or_time(obj)
-    return obj unless [Time, Date, DateTime].include?(obj.class)
-    obj.to_time.to_i
+
+  def valid_date_time_classes
+    list = [Time, Date, DateTime]
+    list << ActiveSupport::TimeWithZone if defined?(ActiveSupport)
+    list
   end
+
+  def convert_date_or_time(obj)
+    return obj unless valid_date_time_classes.include?(obj.class)
+    (obj.respond_to?(:utc) ? obj.utc : obj).strftime("%FT%TZ")
+  end
+
 end
 
 Asari.mode = :sandbox # default to sandbox

--- a/spec/asari_spec.rb
+++ b/spec/asari_spec.rb
@@ -20,6 +20,17 @@ describe "Asari" do
       expect(@asari.aws_region).to eq("us-west-1")
     end
 
+    describe "initialize using hash" do
+      it "sets search_domain" do
+        @asari = Asari.new(search_domain: "test_search_domain")
+        expect(@asari.search_domain).to eq("test_search_domain")
+      end
+      it "sets aws_url" do
+        @asari = Asari.new(search_domain: "test_search_domain", aws_url: "localhost")
+        expect(@asari.search_url).to eq("http://search-test_search_domain.us-east-1.localhost/2011-02-01/search")
+      end
+    end
+
     it "raises an exeception if no search domain is provided." do
       expect { @asari.search_domain }.to raise_error Asari::MissingSearchDomainException
     end

--- a/spec/documents_spec.rb
+++ b/spec/documents_spec.rb
@@ -28,9 +28,9 @@ describe Asari do
       end
     end
 
-    it "converts Time, DateTime, and Date fields to timestamp integers for rankability" do
+    it "converts Time, DateTime, and Date fields to UTC IETF RFC3339: yyyy-mm-ddT00:00:00Z" do
       date = Date.new(2012, 4, 1)
-      HTTParty.should_receive(:post).with("http://doc-testdomain.us-east-1.cloudsearch.amazonaws.com/2011-02-01/documents/batch", { :body => [{ "type" => "add", "id" => "1", "version" => 1, "lang" => "en", "fields" => { :time => 1333263600, :datetime => 1333238400, :date => date.to_time.to_i }}].to_json, :headers => { "Content-Type" => "application/json"}})
+      HTTParty.should_receive(:post).with("http://doc-testdomain.us-east-1.cloudsearch.amazonaws.com/2011-02-01/documents/batch", { :body => [{ "type" => "add", "id" => "1", "version" => 1, "lang" => "en", "fields" => { :time => Time.at(1333263600).utc.strftime("%FT%TZ"), :datetime => DateTime.new(2012, 4, 1).strftime("%FT%TZ"), :date => date.strftime("%FT%TZ")}}].to_json, :headers => { "Content-Type" => "application/json"}})
 
       expect(@asari.add_item("1", {:time => Time.at(1333263600), :datetime => DateTime.new(2012, 4, 1), :date => date})).to eq(nil)
     end
@@ -41,9 +41,9 @@ describe Asari do
       expect(@asari.update_item("1", {:name => "fritters"})).to eq(nil)
     end
 
-    it "converts Time, DateTime, and Date fields to timestamp integers for rankability on update as well" do
+    it "converts Time, DateTime, and Date fields to UTC IETF RFC3339: yyyy-mm-ddT00:00:00Z on update as well" do
       date = Date.new(2012, 4, 1)
-      HTTParty.should_receive(:post).with("http://doc-testdomain.us-east-1.cloudsearch.amazonaws.com/2011-02-01/documents/batch", { :body => [{ "type" => "add", "id" => "1", "version" => 1, "lang" => "en", "fields" => { :time => 1333263600, :datetime => 1333238400, :date => date.to_time.to_i }}].to_json, :headers => { "Content-Type" => "application/json"}})
+      HTTParty.should_receive(:post).with("http://doc-testdomain.us-east-1.cloudsearch.amazonaws.com/2011-02-01/documents/batch", { :body => [{ "type" => "add", "id" => "1", "version" => 1, "lang" => "en", "fields" => { :time => Time.at(1333263600).utc.strftime("%FT%TZ"), :datetime => DateTime.new(2012, 4, 1).strftime("%FT%TZ"), :date => date.strftime("%FT%TZ") }}].to_json, :headers => { "Content-Type" => "application/json"}})
 
       expect(@asari.update_item("1", {:time => Time.at(1333263600), :datetime => DateTime.new(2012, 4, 1), :date => date})).to eq(nil)
     end


### PR DESCRIPTION
* Custom AWS url useful for testing
* Support for ActiveSupport::TimeWithZone: useful when indexing active record.
* Convert Time/Date objects to AWS recommended format instead of timestamp.