### PR TITLE
Allow to use non integer primary keys

### DIFF
--- a/lib/asari/active_record.rb
+++ b/lib/asari/active_record.rb
@@ -178,9 +178,7 @@ class Asari
       #   communicating with the CloudSearch server.
       def asari_find(term, options = {})
         records = self.asari_instance.search(term, options)
-        ids = records.map { |id| id.to_i }
-
-        records.replace(Array(self.where("id in (?)", ids)))
+        records.replace(Array(self.where("id in (?)", records)))
       end
 
       # Public: method for handling errors from Asari document updates. By

--- a/spec/asari/lib/active_record_spec.rb
+++ b/spec/asari/lib/active_record_spec.rb
@@ -43,12 +43,26 @@ describe Asari do
           ActiveRecordFake.asari_find("fritters")
         end
 
-        it "will return a list of model objects when you search" do
-          @asari.should_receive(:search).with("fritters", {}).and_return(["1"])
+        context "will return a list of model objects" do
+          it "when you search for numeric id" do
+            @asari.should_receive(:search).with("fritters", {}).and_return(["1"])
 
-          results = ActiveRecordFake.asari_find("fritters")
-          expect(results.class).to eq(Array)
-          expect(results[0].class).to eq(ActiveRecordFake)
+            results = ActiveRecordFake.asari_find("fritters")
+            expect(results.class).to eq(Array)
+            expect(results[0].class).to eq(ActiveRecordFake)
+          end
+
+          let(:result) { ActiveRecordFake.new(id: "SomeString")}
+
+          it "when you search for string id" do
+            ActiveRecordFake.should_receive(:where).with(an_instance_of(String), ["SomeString"]).and_return([result])
+            @asari.should_receive(:search).with("fritters", {}).and_return(["SomeString"])
+
+            results = ActiveRecordFake.asari_find("fritters")
+            expect(results.class).to eq(Array)
+            expect(results[0].class).to eq(ActiveRecordFake)
+            expect(results.first).to eq(result)
+          end
         end
 
         it "will return an empty list when you search for a term that isn't in the index" do


### PR DESCRIPTION
Hi,

together with @devuatl we prepared a fix, so that you are able to use Asari with models that have non integer primary key.
Please let me know if you have any questions.

Regards,
Krzysztof