### PR TITLE
Using search term when it's specified even if filter options are present

### DIFF
--- a/lib/asari.rb
+++ b/lib/asari.rb
@@ -73,7 +73,10 @@ class Asari
     url = "http://search-#{search_domain}.#{aws_region}.cloudsearch.amazonaws.com/#{api_version}/search"
 
     if api_version == '2013-01-01'
-      if options[:filter]
+      if options[:filter] and term != ""
+        url += "?q=#{CGI.escape("(and '#{term.to_s}' #{bq})")}"
+        url += "&q.parser=structured"
+      elsif options[:filter]
         url += "?q=#{CGI.escape(bq)}"
         url += "&q.parser=structured"
       else

--- a/spec/asari/lib/search_spec.rb
+++ b/spec/asari/lib/search_spec.rb
@@ -131,9 +131,16 @@ describe Asari do
           })
         end
 
-        it "ignores full text search when filter option is used" do
-          HTTParty.should_receive(:get).with("http://search-testdomain.us-east-1.cloudsearch.amazonaws.com/2013-01-01/search?q=%28or+is_donut%3A%27true%27%28and+fried%3A%27true%27%29%29&q.parser=structured&size=10")
+        it "does full text search when filter option is used" do
+          HTTParty.should_receive(:get).with("http://search-testdomain.us-east-1.cloudsearch.amazonaws.com/2013-01-01/search?q=%28and+%27nom%27+%28or+is_donut%3A%27true%27%28and+fried%3A%27true%27%29%29%29&q.parser=structured&size=10")
           @asari.search("nom", filter: { or: { is_donut: true, and:
+                                               { round: "", frosting: nil, fried: true }}
+          })
+        end
+
+        it "uses filters when term is blank" do
+          HTTParty.should_receive(:get).with("http://search-testdomain.us-east-1.cloudsearch.amazonaws.com/2013-01-01/search?q=%28or+is_donut%3A%27true%27%28and+fried%3A%27true%27%29%29&q.parser=structured&size=10")
+          @asari.search("", filter: { or: { is_donut: true, and:
                                                { round: "", frosting: nil, fried: true }}
           })
         end


### PR DESCRIPTION
Hi, 

Together with @krzyho we started building a search app with Cloud Search and chose asari as our wrapper. We discovered that search term would be ignored when filters were provided for a query. It seemed like a bug to us, so we fixed it.

Best,
L