### PR TITLE
Add support for Ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,7 @@ rvm:
   - jruby-head
   - 2.0.0
   - 2.1.2
+  - 2.3.5
+  - 2.4.2
   - ruby-head
 

--- a/lib/asari/collection.rb
+++ b/lib/asari/collection.rb
@@ -73,6 +73,10 @@ class Asari
       ::Asari::Collection
     end
 
+    def respond_to?(method, include_all = false)
+      @data.respond_to?(method, false)
+    end
+
     def method_missing(method, *args, &block)
       @data.send(method, *args, &block)
     end

--- a/lib/asari/collection.rb
+++ b/lib/asari/collection.rb
@@ -78,7 +78,7 @@ class Asari
     end
 
     def method_missing(method, *args, &block)
-      @data.send(method, *args, &block)
+      @data.public_send(method, *args, &block)
     end
   end
 end

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -2,7 +2,7 @@ require_relative '../spec_helper'
 
 describe Asari do
   describe Asari::Collection do
-    before :each do  
+    before :each do
       response = OpenStruct.new(:parsed_response => { "hits" => { "found" => 10, "start" => 0, "hit" => ["1","2"]}})
       @collection = Asari::Collection.new(response, 2)
     end
@@ -25,6 +25,10 @@ describe Asari do
 
     it "calculates the offset correctly" do
       expect(@collection.offset).to eq(0)
+    end
+
+    it "gracefully handles Marshaling" do
+      expect { Marshal.dump @collection }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
### Why

In Ruby 2.3 a regression was introduced in the code that checks if an object responds to a method.

More info:
https://bugs.ruby-lang.org/issues/12353

> The issue is that as of Ruby 2.3, Marshal.dump no longer works with objects that inherit from BasicObject and do not directly define a respond_to? method. This is because vm_respond_to() in vm_method.c returns true if it can not find a method table entry for the respond_to? method, so w_object() in marshal.c tries to call marshal_dump. In Ruby 2.2 and prior, rb_obj_respond_to() would just call respond_to? instead of checking for a method table entry, so method_missing could receive the respond_to?.

**Before (on master)**
```
$ ruby -Ilib -rasari -e "p Marshal.dump Asari::Collection.sandbox_fake"
/Users/andrew/Code/ruby/asari/lib/asari/collection.rb:77:in `method_missing': undefined method `marshal_dump' for []:Array (NoMethodError)
	from -e:1:in `dump'
	from -e:1:in `<main>'
```
**After (this branch)**

```
$ ruby -Ilib -rasari -e "p Marshal.dump Asari::Collection.sandbox_fake"
"\x04\bo:\x16Asari::Collection\n:\x13@total_entriesi\x00:\x0F@page_sizei\x0F:\x11@total_pagesi\x06:\x12@current_pagei\x06:\n@data[\x00"
```

### What

This adds a workaround for the issue mentioned above by implementing `respond_to?` in `Asari::Collection` – Another solution might be to change `Asari::Collection` so it subclasses `Object` instead of `BasicObject`